### PR TITLE
Fix "parent directory does not exist" on model save.

### DIFF
--- a/trainModel.py
+++ b/trainModel.py
@@ -98,7 +98,7 @@ n_hidden_units_one = 256
 n_hidden_units_two = 256
 sd = 1 / np.sqrt(n_dim)
 learning_rate = 0.01
-model_path = "model"
+model_path = "./model"
 
 X = tf.placeholder(tf.float32, [None, n_dim])
 Y = tf.placeholder(tf.float32, [None, n_classes])


### PR DESCRIPTION
I was training on my local machine with tensorflow v1.11.0.

When 5000 epochs done, it throws an error about model path.